### PR TITLE
AJ-116: Lua syntax + StyLua format check in CI

### DIFF
--- a/.github/scripts/lualint-rendered.sh
+++ b/.github/scripts/lualint-rendered.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Lint rendered Lua files and chezmoi Lua templates.
+#
+# Walks the rendered destination tree (output of `chezmoi apply --destination`)
+# and the chezmoi source tree, and runs:
+#   1. `luac -p` syntax check on every rendered `.lua` file.
+#   2. For every `.lua.tmpl` source file: render via `chezmoi execute-template`
+#      and run `luac -p` on the rendered output.
+#   3. `stylua --check` on each rendered subtree that contains a `stylua.toml`.
+#
+# Templates that render to empty content (e.g. a darwin-only block on a linux
+# runner) are skipped. StyLua is skipped if not installed; syntax check is the
+# hard requirement.
+
+set -euo pipefail
+
+RENDERED_DIR="${1:-/tmp/chezmoi-dest}"
+SOURCE_DIR="${2:-$PWD}"
+
+# Pick a luac binary. Prefer plain `luac` (whatever the OS provides), fall
+# back to versioned binaries that Debian/Ubuntu ships under explicit names.
+LUAC="${LUAC:-}"
+if [[ -z "$LUAC" ]]; then
+	for cand in luac luac5.4 luac5.3 luac5.1; do
+		if command -v "$cand" >/dev/null 2>&1; then
+			LUAC="$cand"
+			break
+		fi
+	done
+fi
+if [[ -z "$LUAC" ]]; then
+	echo "::error::no luac binary found on PATH (tried luac, luac5.4, luac5.3, luac5.1)"
+	exit 2
+fi
+
+syntax_failures=0
+syntax_checked=0
+
+run_luac() {
+	local path="$1"
+	local label="${2:-$path}"
+	syntax_checked=$((syntax_checked + 1))
+	local out
+	if ! out=$("$LUAC" -p "$path" 2>&1); then
+		echo "::error file=${label}::luac -p failed"
+		# Rewrite the temp path back to the friendly label so users can locate
+		# the source file from the error output.
+		printf '%s\n' "$out" | sed "s|$path|$label|g"
+		syntax_failures=$((syntax_failures + 1))
+	fi
+}
+
+echo "==> Syntax-checking rendered .lua files in $RENDERED_DIR (using $LUAC)"
+if [[ -d "$RENDERED_DIR" ]]; then
+	while IFS= read -r -d '' file; do
+		run_luac "$file" "${file#"$RENDERED_DIR"/}"
+	done < <(find "$RENDERED_DIR" -type f -name '*.lua' -print0)
+else
+	echo "  (skipped: directory not present)"
+fi
+
+echo "==> Rendering and syntax-checking .lua.tmpl source files in $SOURCE_DIR"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cz_args=(--source="$SOURCE_DIR")
+if [[ -n "${CHEZMOI_CONFIG_FILE:-}" ]]; then
+	cz_args+=(--config="$CHEZMOI_CONFIG_FILE")
+fi
+
+while IFS= read -r -d '' src; do
+	rel="${src#"$SOURCE_DIR"/}"
+	# Flat tmp filename keeps traceability in tool output; drop .tmpl so
+	# the rendered file has a `.lua` extension that stylua/luac recognize.
+	rendered_path="$tmpdir/${rel//\//__}"
+	rendered_path="${rendered_path%.tmpl}"
+
+	if ! chezmoi execute-template "${cz_args[@]}" <"$src" >"$rendered_path"; then
+		echo "::error file=${rel}::chezmoi execute-template failed"
+		syntax_failures=$((syntax_failures + 1))
+		continue
+	fi
+
+	# Skip empty renders (e.g. an OS-only block on a different runner).
+	if [[ ! -s "$rendered_path" ]]; then
+		continue
+	fi
+
+	run_luac "$rendered_path" "$rel"
+done < <(
+	find "$SOURCE_DIR" -name '*.lua.tmpl' -type f \
+		-not -path "$SOURCE_DIR/.git/*" \
+		-not -path "$SOURCE_DIR/.worktrees/*" \
+		-print0
+)
+
+# StyLua format check — runs once per rendered subtree that ships a
+# `stylua.toml`. This lets each tool (nvim, hammerspoon, ...) carry its own
+# style without forcing repo-wide rules.
+stylua_failures=0
+stylua_checked=0
+echo "==> StyLua format check (rendered subtrees with stylua.toml)"
+if ! command -v stylua >/dev/null 2>&1; then
+	echo "  (skipped: stylua not installed)"
+elif [[ -d "$RENDERED_DIR" ]]; then
+	while IFS= read -r -d '' cfg; do
+		dir=$(dirname "$cfg")
+		rel="${dir#"$RENDERED_DIR"/}"
+		echo "  checking $rel/"
+		stylua_checked=$((stylua_checked + 1))
+		if ! stylua --check "$dir"; then
+			echo "::error file=${rel}::stylua --check failed"
+			stylua_failures=$((stylua_failures + 1))
+		fi
+	done < <(find "$RENDERED_DIR" -type f -name 'stylua.toml' -print0)
+	if ((stylua_checked == 0)); then
+		echo "  (no stylua.toml found in rendered tree)"
+	fi
+else
+	echo "  (skipped: rendered directory not present)"
+fi
+
+echo
+echo "Lua syntax ($LUAC -p): $syntax_checked file(s) checked, $syntax_failures failure(s)"
+echo "StyLua format check: $stylua_checked subtree(s) checked, $stylua_failures failure(s)"
+
+if ((syntax_failures > 0 || stylua_failures > 0)); then
+	exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,20 @@ jobs:
       - name: ShellCheck rendered scripts and run scripts
         run: .github/scripts/shellcheck-rendered.sh /tmp/chezmoi-dest "$GITHUB_WORKSPACE"
 
+      - name: Install Lua + StyLua
+        run: |
+          sudo apt-get install -y --no-install-recommends lua5.4
+          # StyLua isn't in the default apt repos; pull a release binary.
+          STYLUA_VERSION=2.4.1
+          curl -fsSL -o /tmp/stylua.zip \
+            "https://github.com/JohnnyMorganz/StyLua/releases/download/v${STYLUA_VERSION}/stylua-linux-x86_64.zip"
+          unzip -o /tmp/stylua.zip -d "$HOME/.local/bin"
+          chmod +x "$HOME/.local/bin/stylua"
+          stylua --version
+
+      - name: Lua syntax + StyLua format check
+        run: .github/scripts/lualint-rendered.sh /tmp/chezmoi-dest "$GITHUB_WORKSPACE"
+
       - name: Upload rendered output
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/dot_config/nvim/lua/exact_config/keymaps.lua
+++ b/dot_config/nvim/lua/exact_config/keymaps.lua
@@ -16,7 +16,8 @@ vim.keymap.set("n", "<leader>fy", function()
   local path
 
   -- Try to get path relative to git root
-  local git_root = vim.fn.systemlist("git -C " .. vim.fn.shellescape(vim.fn.expand("%:p:h")) .. " rev-parse --show-toplevel")[1]
+  local git_root =
+    vim.fn.systemlist("git -C " .. vim.fn.shellescape(vim.fn.expand("%:p:h")) .. " rev-parse --show-toplevel")[1]
   if vim.v.shell_error == 0 and git_root then
     -- In a git repo, use path relative to git root
     path = vim.fn.fnamemodify(abs_path, ":s?" .. git_root .. "/??")

--- a/dot_config/nvim/lua/exact_plugins/lualine.lua
+++ b/dot_config/nvim/lua/exact_plugins/lualine.lua
@@ -1,25 +1,25 @@
 return {
-	{
-		"nvim-lualine/lualine.nvim",
-		event = "VeryLazy",
-		opts = function(_, opts)
-			local icons = LazyVim.config.icons
+  {
+    "nvim-lualine/lualine.nvim",
+    event = "VeryLazy",
+    opts = function(_, opts)
+      local icons = LazyVim.config.icons
 
-			opts.sections["lualine_z"] = {}
-			opts.sections["lualine_c"] = {
-				-- LazyVim.lualine.root_dir(),
-				{
-					"diagnostics",
-					symbols = {
-						error = icons.diagnostics.Error,
-						warn = icons.diagnostics.Warn,
-						info = icons.diagnostics.Info,
-						hint = icons.diagnostics.Hint,
-					},
-				},
-				{ "filetype", icon_only = true, separator = "", padding = { left = 1, right = 0 } },
-				{ LazyVim.lualine.pretty_path({ relative = "root", length = 0 }) },
-			}
-		end,
-	},
+      opts.sections["lualine_z"] = {}
+      opts.sections["lualine_c"] = {
+        -- LazyVim.lualine.root_dir(),
+        {
+          "diagnostics",
+          symbols = {
+            error = icons.diagnostics.Error,
+            warn = icons.diagnostics.Warn,
+            info = icons.diagnostics.Info,
+            hint = icons.diagnostics.Hint,
+          },
+        },
+        { "filetype", icon_only = true, separator = "", padding = { left = 1, right = 0 } },
+        { LazyVim.lualine.pretty_path({ relative = "root", length = 0 }) },
+      }
+    end,
+  },
 }

--- a/dot_config/nvim/lua/exact_plugins/windows.lua
+++ b/dot_config/nvim/lua/exact_plugins/windows.lua
@@ -2,18 +2,18 @@ return {
   {
     "christoomey/vim-tmux-navigator",
     cmd = {
-        "TmuxNavigateLeft",
-        "TmuxNavigateDown",
-        "TmuxNavigateUp",
-        "TmuxNavigateRight",
-        "TmuxNavigatePrevious",
+      "TmuxNavigateLeft",
+      "TmuxNavigateDown",
+      "TmuxNavigateUp",
+      "TmuxNavigateRight",
+      "TmuxNavigatePrevious",
     },
     keys = {
-        { "<c-h>", "<cmd><C-U>TmuxNavigateLeft<cr>" },
-        { "<c-j>", "<cmd><C-U>TmuxNavigateDown<cr>" },
-        { "<c-k>", "<cmd><C-U>TmuxNavigateUp<cr>" },
-        { "<c-l>", "<cmd><C-U>TmuxNavigateRight<cr>" },
-        { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
+      { "<c-h>", "<cmd><C-U>TmuxNavigateLeft<cr>" },
+      { "<c-j>", "<cmd><C-U>TmuxNavigateDown<cr>" },
+      { "<c-k>", "<cmd><C-U>TmuxNavigateUp<cr>" },
+      { "<c-l>", "<cmd><C-U>TmuxNavigateRight<cr>" },
+      { "<c-\\>", "<cmd><C-U>TmuxNavigatePrevious<cr>" },
     },
-    }
+  },
 }


### PR DESCRIPTION
## Summary

Adds a tier-1 CI step that catches Lua template-rendering errors before they hit deploy, mirroring the ShellCheck and Python validation steps already in place. Closes [AJ-116](https://linear.app/adam-jackman/issue/AJ-116).

## Changes

- **`.github/scripts/lualint-rendered.sh`** — new helper that:
  - syntax-checks every rendered \`.lua\` file under \`/tmp/chezmoi-dest\` with \`luac -p\`,
  - renders each \`*.lua.tmpl\` source via \`chezmoi execute-template\` and syntax-checks the rendered output (so non-deployable Lua templates are still covered),
  - runs \`stylua --check\` on every rendered subtree that ships a \`stylua.toml\` (currently only \`dot_config/nvim/\`).
- **\`.github/workflows/ci.yml\`** — install \`lua5.4\` (provides \`luac5.4\`) and a pinned StyLua release binary, then invoke the new script.
- **\`dot_config/nvim/lua/{exact_config/keymaps,exact_plugins/lualine,exact_plugins/windows}.lua\`** — reformatted with StyLua so they match the existing \`dot_config/nvim/stylua.toml\`. Pure formatting; no behavior change (verified with \`git diff -w\`).

Hammerspoon currently has no \`stylua.toml\`, so it gets syntax-checked but not format-checked. A follow-up could add one along with a \`.styluaignore\` for vendored Spoons.

## Testing

Locally (matches the CI matrix):

\`\`\`sh
chezmoi apply --source=\$PWD --destination=/tmp/aj116-render \\
  --exclude=scripts,externals --force --no-tty
.github/scripts/lualint-rendered.sh /tmp/aj116-render \"\$PWD\"
\`\`\`

Verified across all three \`extras\` matrix variants (\`[]\`, \`[\"personal\"]\`, \`[\"moov\"]\`):

\`\`\`
Lua syntax (luac -p): 35 file(s) checked, 0 failure(s)
StyLua format check: 1 subtree(s) checked, 0 failure(s)
\`\`\`

Failure path was also confirmed (broken Lua → \`luac -p\` and \`stylua --check\` both surface the error and the script exits 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)